### PR TITLE
Loading circle upon login is now centered.

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -75,7 +75,7 @@
     <style name="Login.ProgressBar" parent="android:Widget.ProgressBar.Large">
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_centerHorizontal">true</item>
+        <item name="android:layout_centerInParent">true</item>
         <item name="android:layout_marginBottom">8dp</item>
         <item name="android:visibility">gone</item>
     </style>


### PR DESCRIPTION
Attempted to have it flash the splash screen upon logging in. However, the load time for the image (at least on my emulator) appeared to be greater than the time it took for the background process to successfully login.

Trying it with my phone led to a few other issues, including the above, so I scrapped it and settled for a  centered loading circle.
